### PR TITLE
Supports high-speed (5G/10G) instead of USB 3.X 480M

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -469,7 +469,7 @@
 			<key>ThirdPartyDrives</key>
 			<false/>
 			<key>XhciPortLimit</key>
-			<false/>
+			<true/>
 		</dict>
 		<key>Scheme</key>
 		<dict>


### PR DESCRIPTION
XhciPortLimit must be enabled for 10Gbps NVMe enclosure support.